### PR TITLE
Allowed ability for arguments to be passed via config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "REGION": "US",
-    "LANG": "en"
+    "REGION": "AR",
+    "LANG": "es"
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+    "REGION": "US",
+    "LANG": "en"
+}

--- a/get-product-detail-catalog.js
+++ b/get-product-detail-catalog.js
@@ -1,5 +1,7 @@
 import fetch from 'node-fetch';
 
+import config from './config.json' assert {type: "json"};
+
 const API_PRODUCT_DETAIL_CATALOG = 'https://displaycatalog.mp.microsoft.com/v7.0/products/';
 
 /**
@@ -12,8 +14,8 @@ function mapProducts(products) {
     // TODO: Code smell
     const url = new URL(API_PRODUCT_DETAIL_CATALOG);
     const params = {
-      market: 'ar',
-      languages: 'es-ar',
+      market: config.REGION,
+      languages: `${config.LANG+"-"+config.REGION}`,
       bigIds: element.ProductId,
     }
 
@@ -71,8 +73,8 @@ async function getProductDetailCatalog(productIds = ['9NJRX71M5X9P', '9N9J38LPVS
 
   const url = new URL(API_PRODUCT_DETAIL_CATALOG);
   const params = {
-    market: 'ar',
-    languages: 'es-ar',
+    market: config.REGION,
+    languages: `${config.LANG+"-"+config.REGION}`,
     bigIds: productIds.join(','),
   }
 

--- a/get-product-id-list.js
+++ b/get-product-id-list.js
@@ -1,5 +1,7 @@
 import fetch from 'node-fetch';
 
+import config from './config.json' assert {type: "json"};
+
 const API_PRODUCT_ID_LIST = 'https://reco-public.rec.mp.microsoft.com/channels/Reco/V8.0/Lists/';
 
 const PRODUCT_ID_LISTS = {
@@ -16,8 +18,8 @@ const PRODUCT_ID_LISTS = {
 async function getProductIdsList(list = 'Deal') {
   const url = new URL(`${API_PRODUCT_ID_LIST}${PRODUCT_ID_LISTS[list]}`);
   const params = {
-    market: 'ar',
-    language: 'es-ar',
+    market: config.REGION,
+    language: `${config.LANG+"-"+config.REGION}`,
     itemTypes: 'Game',
     deviceFamily: 'Windows.Xbox',
     count: '2000',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "type": "module",
+  "scripts": {
+    "dev": "node --experimental-json-modules index.js"
+  },
   "dependencies": {
     "node-fetch": "^3.2.3"
   }


### PR DESCRIPTION
So far, this (should) allow better configuration for different markets (NA, EU, etc.) in the future through command line arguments.

Currently at the moment however, due to JSON imports for this to work you'd have to run `npm run dev` for it to run.

I didn't notice this branch until I planned to make a different pull request so I decided to just make one here because this would most likely get pushed to the master branch sometime soon.